### PR TITLE
Method interfaceToModel in FHIRAppointmentAdapter 

### DIFF
--- a/src/Adapters/FHIRAppointmentAdapter.php
+++ b/src/Adapters/FHIRAppointmentAdapter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LibreEHR\FHIR\Adapters;
+
+use Illuminate\Http\Request;
+use LibreEHR\Core\Contracts\BaseAdapterInterface ;
+
+
+class FHIRAppointmentAdapter implements BaseAdapterInterface
+{
+
+    public function retrieve( $id )
+    {
+
+    }
+    public function store( Request $request )
+    {
+
+    }
+    public function collectionToOutput()
+    {
+
+    }
+}

--- a/src/Adapters/FHIRAppointmentAdapter.php
+++ b/src/Adapters/FHIRAppointmentAdapter.php
@@ -33,7 +33,7 @@ class FHIRAppointmentAdapter extends AbstractFHIRAdapter implements BaseAdapterI
 
     /**
      * @param Request $request
-     * @return FHIRPatient
+     * @return FHIRAppointment
      */
     public function store( Request $request )
     {
@@ -45,13 +45,13 @@ class FHIRAppointmentAdapter extends AbstractFHIRAdapter implements BaseAdapterI
     }
 
     /**
-     * @param PatientInterface $patientInterface
-     * @return PatientInterface
+     * @param AppointmentInterface $appointmentInterface
+     * @return AppointmentInterface
      */
-    public function storeInterface( PatientInterface $patientInterface )
+    public function storeInterface( AppointmentInterface $appointmentInterface )
     {
-        $patientInterface = $this->repository->create( $patientInterface );
-        return $patientInterface;
+        $appointmentInterface = $this->repository->create( $appointmentInterface );
+        return $appointmentInterface;
     }
 
     /**
@@ -75,19 +75,22 @@ class FHIRAppointmentAdapter extends AbstractFHIRAdapter implements BaseAdapterI
 
     /**
      * @param string $data
-     * @return PatientInterface
+     * @return AppointmentInterface
      *
-     * Takes a FHIR post string and returns a PatientInterface
+     * Takes a FHIR post string and returns a AppointmentInterface
      */
     public function jsonToInterface( $data )
     {
-        $parser = new \PHPFHIRGenerated\PHPFHIRResponseParser();
-        $fhirPatient = $parser->parse( $data );
-        if ( is_a( $fhirPatient, 'FHIRPatient' ) ) {
-            return $this->modelToInterface( $fhirPatient );
+        $data_test = '{"resourceType":"Appointment","identifier":[{"use":"usual","value":1}],"start":"10:00:00","end":"10:15:00"}';
+
+        $parser = new PHPFHIRResponseParser();
+        $fhirAppointment = $parser->parse( $data_test );
+        if ( $fhirAppointment instanceof FHIRAppointment ) {
+            return $this->modelToInterface( $fhirAppointment );
         } else {
-            // Error, the Resource does not match, expecting a Patient,
+            // Error, the Resource does not match, expecting a Appointment,
             // // but got something else.
+            echo 'Error, the Resource does not match, expecting a Appointment';
         }
 
 
@@ -95,12 +98,18 @@ class FHIRAppointmentAdapter extends AbstractFHIRAdapter implements BaseAdapterI
 
     public function modelToInterface( FHIRAppointment $fhirAppointment )
     {
-        $data_zzz = '{"resourceType":"Appointment","identifier":[{"use":"usual","value":1}],"start":"10:00:00","end":"10:15:00"}';
-        $parser = new PHPFHIRResponseParser();
-        $appointment = $parser->parse($data_zzz);
-        $start = $appointment->getStart()->getValue();
+        $appointmentInterface = App::make('LibreEHR\Core\Contracts\AppointmentInterface');
+        if ($appointmentInterface instanceof AppointmentInterface) {
 
-        return $start;
+            $start = $fhirAppointment->getStart()->getValue();
+            $appointmentInterface->setStartTime( $start );
+
+            $end = $fhirAppointment->getEnd()->getValue();
+            $appointmentInterface->setEndTime( $end );
+
+        }
+
+        return $appointmentInterface;
     }
 
     /**

--- a/src/Adapters/FHIRAppointmentAdapter.php
+++ b/src/Adapters/FHIRAppointmentAdapter.php
@@ -3,22 +3,135 @@
 namespace LibreEHR\FHIR\Adapters;
 
 use Illuminate\Http\Request;
-use LibreEHR\Core\Contracts\BaseAdapterInterface ;
+use LibreEHR\Core\Contracts\BaseAdapterInterface;
+use LibreEHR\Core\Contracts\AppointmentInterface;
+use LibreEHR\Core\Emr\Criteria\ByPid;
+use PHPFHIRGenerated\FHIRDomainResource\FHIRAppointment;
+use PHPFHIRGenerated\FHIRElement\FHIRIdentifier;
+use PHPFHIRGenerated\FHIRElement\FHIRIdentifierUse;
+use PHPFHIRGenerated\FHIRElement\FHIRString;
+use PHPFHIRGenerated\FHIRElement\FHIRInstant;
+use PHPFHIRGenerated\PHPFHIRResponseParser;
+use Illuminate\Support\Facades\App;
 
-
-class FHIRAppointmentAdapter implements BaseAdapterInterface
+class FHIRAppointmentAdapter extends AbstractFHIRAdapter implements BaseAdapterInterface
 {
 
+    /**
+     * @param $id ID identifying resource
+     * @return string
+     *
+     * Takes a resource ID and returns a FHIR JSON or XML string
+     * in response
+     */
     public function retrieve( $id )
     {
-
+        $this->repository->finder()->pushCriteria( new ByPid( $id ) );
+        $patientInterface = $this->repository->find();
+        return $this->interfaceToModel( $patientInterface );
     }
+
+    /**
+     * @param Request $request
+     * @return FHIRPatient
+     */
     public function store( Request $request )
     {
-
+        // TODO add validation
+        $data = $request->getContent();
+        $interface = $this->jsonToInterface( $data );
+        $storedInterface = $this->storeInterface( $interface );
+        return $this->interfaceToModel( $storedInterface );
     }
+
+    /**
+     * @param PatientInterface $patientInterface
+     * @return PatientInterface
+     */
+    public function storeInterface( PatientInterface $patientInterface )
+    {
+        $patientInterface = $this->repository->create( $patientInterface );
+        return $patientInterface;
+    }
+
+    /**
+     * @param ArrayAccess $collection
+     * @return array
+     */
     public function collectionToOutput()
     {
+        $collection = $this->repository->fetchAll();
+        $output = array();
+        foreach ( $collection as $appointment ) {
 
+            if ( $appointment instanceof AppointmentInterface ) {
+                $fhirAppointment = $this->interfaceToModel( $appointment );
+                $output[]= $fhirAppointment;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param string $data
+     * @return PatientInterface
+     *
+     * Takes a FHIR post string and returns a PatientInterface
+     */
+    public function jsonToInterface( $data )
+    {
+        $parser = new \PHPFHIRGenerated\PHPFHIRResponseParser();
+        $fhirPatient = $parser->parse( $data );
+        if ( is_a( $fhirPatient, 'FHIRPatient' ) ) {
+            return $this->modelToInterface( $fhirPatient );
+        } else {
+            // Error, the Resource does not match, expecting a Patient,
+            // // but got something else.
+        }
+
+
+    }
+
+    public function modelToInterface( FHIRAppointment $fhirAppointment )
+    {
+        $data_zzz = '{"resourceType":"Appointment","identifier":[{"use":"usual","value":1}],"start":"10:00:00","end":"10:15:00"}';
+        $parser = new PHPFHIRResponseParser();
+        $appointment = $parser->parse($data_zzz);
+        $start = $appointment->getStart()->getValue();
+
+        return $start;
+    }
+
+    /**
+     * @param AppointmentInterface $appointment
+     * @return FHIRAppointment
+     */
+    public function interfaceToModel( AppointmentInterface $appointment )
+    {
+        $fhirAppointment = new FHIRAppointment();
+
+        $identifier = new FHIRIdentifier();
+        $use = new FHIRIdentifierUse();
+        $use->setValue( "usual" );
+        $identifier->setUse( $use );
+        $value = new FHIRString();
+        $value->setValue( $appointment->getId() );
+        $identifier->setValue( $value );
+        $fhirAppointment->addIdentifier( $identifier );
+
+        $start = new FHIRInstant();
+        $value = new FHIRString();
+        $value->setValue( $appointment->getStartTime() );
+        $start->setValue( $value );
+        $fhirAppointment->setStart($start);
+
+        $end = new FHIRInstant();
+        $value = new FHIRString();
+        $value->setValue( $appointment->getEndTime() );
+        $end->setValue( $value );
+        $fhirAppointment->setEnd($end);
+
+        return $fhirAppointment;
     }
 }

--- a/src/Adapters/FHIRPatientAdapter.php
+++ b/src/Adapters/FHIRPatientAdapter.php
@@ -8,6 +8,7 @@ use LibreEHR\Core\Contracts\PatientAdapterInterface;
 use LibreEHR\Core\Contracts\PatientInterface;
 use LibreEHR\Core\Contracts\DocumentInterface;
 
+use LibreEHR\Core\Contracts\BaseAdapterInterface;
 use LibreEHR\Core\Contracts\PatientRepositoryInterface;
 use LibreEHR\Core\Emr\Criteria\ByPid;
 use LibreEHR\Core\Emr\Criteria\PatientByPid;

--- a/src/Adapters/FHIRScheduleAdapter.php
+++ b/src/Adapters/FHIRScheduleAdapter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace LibreEHR\FHIR\Adapters;
+
+use Illuminate\Http\Request;
+use LibreEHR\Core\Contracts\BaseAdapterInterface;
+use LibreEHR\Core\Contracts\AppointmentInterface;
+
+use PHPFHIRGenerated\FHIRDomainResource\FHIRAppointment;
+
+
+class FHIRScheduleAdapter extends AbstractFHIRAdapter implements BaseAdapterInterface
+{
+
+    /**
+     * @param $id ID identifying resource
+     * @return string
+     *
+     * Takes a resource ID and returns a FHIR JSON or XML string
+     * in response
+     */
+    public function retrieve( $id )
+    {
+
+    }
+
+    /**
+     * @param Request $request
+     * @return FHIRPatient
+     */
+    public function store( Request $request )
+    {
+
+    }
+
+    /**
+     * @param PatientInterface $patientInterface
+     * @return PatientInterface
+     */
+    public function storeInterface( AppointmentInterface $appointmentInterface)
+    {
+
+    }
+
+    /**
+     * @param ArrayAccess $collection
+     * @return array
+     */
+    public function collectionToOutput()
+    {
+
+    }
+
+    /**
+     * @param string $data
+     * @return PatientInterface
+     *
+     * Takes a FHIR post string and returns a PatientInterface
+     */
+    public function jsonToInterface( $data )
+    {
+
+
+    }
+
+    public function modelToInterface( FHIRAppointment $fhirAppointment )
+    {
+
+    }
+
+    /**
+     * @param AppointmentInterface $appointment
+     * @return FHIRAppointment
+     */
+    public function interfaceToModel( AppointmentInterface $appointment )
+    {
+
+    }
+}

--- a/src/Adapters/FHIRSlotAdapter.php
+++ b/src/Adapters/FHIRSlotAdapter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace LibreEHR\FHIR\Adapters;
+
+use Illuminate\Http\Request;
+use LibreEHR\Core\Contracts\BaseAdapterInterface;
+use LibreEHR\Core\Contracts\AppointmentInterface;
+
+use PHPFHIRGenerated\FHIRDomainResource\FHIRAppointment;
+
+
+class FHIRSlotAdapter extends AbstractFHIRAdapter implements BaseAdapterInterface
+{
+
+    /**
+     * @param $id ID identifying resource
+     * @return string
+     *
+     * Takes a resource ID and returns a FHIR JSON or XML string
+     * in response
+     */
+    public function retrieve( $id )
+    {
+
+    }
+
+    /**
+     * @param Request $request
+     * @return FHIRPatient
+     */
+    public function store( Request $request )
+    {
+
+    }
+
+    /**
+     * @param PatientInterface $patientInterface
+     * @return PatientInterface
+     */
+    public function storeInterface( AppointmentInterface $appointmentInterface)
+    {
+
+    }
+
+    /**
+     * @param ArrayAccess $collection
+     * @return array
+     */
+    public function collectionToOutput()
+    {
+
+    }
+
+    /**
+     * @param string $data
+     * @return PatientInterface
+     *
+     * Takes a FHIR post string and returns a PatientInterface
+     */
+    public function jsonToInterface( $data )
+    {
+
+
+    }
+
+    public function modelToInterface( FHIRAppointment $fhirAppointment )
+    {
+
+    }
+
+    /**
+     * @param AppointmentInterface $appointment
+     * @return FHIRAppointment
+     */
+    public function interfaceToModel( AppointmentInterface $appointment )
+    {
+
+    }
+}

--- a/src/Http/Controllers/AppointmentController.php
+++ b/src/Http/Controllers/AppointmentController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace LibreEHR\FHIR\Http\Controllers;
+
+use Illuminate\Http\Request;
+use LibreEHR\FHIR\Adapters\FHIRAppointmentAdapter;
+use Illuminate\Support\Facades\DB;
+use phpDocumentor\Reflection\DocBlock\Tags\Return_;
+
+class AppointmentController extends AbstractController
+{
+    public function __construct()
+    {
+        $this->adapter = new FHIRAppointmentAdapter;
+    }
+
+    public function index()
+    {
+
+    }
+
+    public function getSchedule()
+    {
+        $results = DB::select('select * from openemr_postcalendar_events');
+        $json = json_encode($results);
+
+        return $json;
+    }
+
+    public function addSlot( Request $request )
+    {
+        $start = $request->input('start');
+        $end = $request->input('end');
+        $pid = $request->input('pid');
+
+        $result = DB::insert('insert into openemr_postcalendar_events (pc_pid, pc_startTime, pc_endTime) values (?, ?, ?)', [$pid, $start, $end]);
+
+        return json_encode($result);
+    }
+
+    public function checkStatus(  Request $request )
+    {
+        $pc_eid = $request->input('pc_eid');
+        $result = DB::select('select pc_apptstatus from openemr_postcalendar_events  where pc_eid = ?', [$pc_eid]);
+
+        return json_encode($result);
+    }
+
+}
+

--- a/src/Http/Controllers/AppointmentController.php
+++ b/src/Http/Controllers/AppointmentController.php
@@ -15,7 +15,8 @@ class AppointmentController extends AbstractController
 
     public function index()
     {
-        return $this->appointmentAdapter->collectionToOutput();
+        //return $this->appointmentAdapter->collectionToOutput();
+        $this->appointmentAdapter->jsonToInterface(1);
     }
 
 }

--- a/src/Http/Controllers/AppointmentController.php
+++ b/src/Http/Controllers/AppointmentController.php
@@ -2,48 +2,20 @@
 
 namespace LibreEHR\FHIR\Http\Controllers;
 
-use Illuminate\Http\Request;
-use LibreEHR\FHIR\Adapters\FHIRAppointmentAdapter;
-use Illuminate\Support\Facades\DB;
-use phpDocumentor\Reflection\DocBlock\Tags\Return_;
+use LibreEHR\Core\Contracts\BaseAdapterInterface;
 
 class AppointmentController extends AbstractController
 {
-    public function __construct()
+    protected $appointmentAdapter = null;
+
+    public function __construct( BaseAdapterInterface $appointmentAdapter )
     {
-        $this->adapter = new FHIRAppointmentAdapter;
+        $this->appointmentAdapter = $appointmentAdapter;
     }
 
     public function index()
     {
-
-    }
-
-    public function getSchedule()
-    {
-        $results = DB::select('select * from openemr_postcalendar_events');
-        $json = json_encode($results);
-
-        return $json;
-    }
-
-    public function addSlot( Request $request )
-    {
-        $start = $request->input('start');
-        $end = $request->input('end');
-        $pid = $request->input('pid');
-
-        $result = DB::insert('insert into openemr_postcalendar_events (pc_pid, pc_startTime, pc_endTime) values (?, ?, ?)', [$pid, $start, $end]);
-
-        return json_encode($result);
-    }
-
-    public function checkStatus(  Request $request )
-    {
-        $pc_eid = $request->input('pc_eid');
-        $result = DB::select('select pc_apptstatus from openemr_postcalendar_events  where pc_eid = ?', [$pc_eid]);
-
-        return json_encode($result);
+        return $this->appointmentAdapter->collectionToOutput();
     }
 
 }

--- a/src/Http/Controllers/ScheduleController.php
+++ b/src/Http/Controllers/ScheduleController.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: User
+ * Date: 08.08.2016
+ * Time: 11:55
+ */

--- a/src/Http/Controllers/ScheduleController.php
+++ b/src/Http/Controllers/ScheduleController.php
@@ -1,7 +1,9 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: User
- * Date: 08.08.2016
- * Time: 11:55
- */
+namespace LibreEHR\FHIR\Http\Controllers;
+
+use App\Http\Requests;
+
+class ScheduleController extends AbstractController
+{
+
+}

--- a/src/Http/Controllers/SlotController.php
+++ b/src/Http/Controllers/SlotController.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: User
+ * Date: 08.08.2016
+ * Time: 12:00
+ */

--- a/src/Http/Controllers/SlotController.php
+++ b/src/Http/Controllers/SlotController.php
@@ -1,7 +1,9 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: User
- * Date: 08.08.2016
- * Time: 12:00
- */
+namespace LibreEHR\FHIR\Http\Controllers;
+
+use App\Http\Requests;
+
+class SlotController extends AbstractController
+{
+
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -6,6 +6,10 @@ Route::group(['prefix' => 'fhir'], function () {
     Route::resource('Patient', '\LibreEHR\FHIR\Http\Controllers\PatientController');
     Route::resource('Patients', '\LibreEHR\FHIR\Http\Controllers\PatientController');
 
+    Route::resource('get_schedule', '\LibreEHR\FHIR\Http\Controllers\AppointmentController@getSchedule');
+    Route::resource('add_slot', '\LibreEHR\FHIR\Http\Controllers\AppointmentController@addSlot');
+    Route::resource('check_status', '\LibreEHR\FHIR\Http\Controllers\AppointmentController@checkStatus');
+
     Route::resource('conformance', '\LibreEHR\FHIR\Http\Controllers\ConformanceController');
     Route::resource('metadata', '\LibreEHR\FHIR\Http\Controllers\ConformanceController');
 

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -6,9 +6,7 @@ Route::group(['prefix' => 'fhir'], function () {
     Route::resource('Patient', '\LibreEHR\FHIR\Http\Controllers\PatientController');
     Route::resource('Patients', '\LibreEHR\FHIR\Http\Controllers\PatientController');
 
-    Route::resource('get_schedule', '\LibreEHR\FHIR\Http\Controllers\AppointmentController@getSchedule');
-    Route::resource('add_slot', '\LibreEHR\FHIR\Http\Controllers\AppointmentController@addSlot');
-    Route::resource('check_status', '\LibreEHR\FHIR\Http\Controllers\AppointmentController@checkStatus');
+    Route::resource('Appointment', '\LibreEHR\FHIR\Http\Controllers\AppointmentController');
 
     Route::resource('conformance', '\LibreEHR\FHIR\Http\Controllers\ConformanceController');
     Route::resource('metadata', '\LibreEHR\FHIR\Http\Controllers\ConformanceController');

--- a/src/Utilities/Providers/FHIRServiceProvider.php
+++ b/src/Utilities/Providers/FHIRServiceProvider.php
@@ -24,6 +24,18 @@ class FHIRServiceProvider extends ServiceProvider
             return new \LibreEHR\Core\Emr\Eloquent\PatientData();
         });
 
+
+        // When AppointmentController needs Adapter Logic point IoC to give the FHIRAppointmentAdapter
+        $this->app->when( 'LibreEHR\FHIR\Http\Controllers\AppointmentController' )
+            ->needs( 'LibreEHR\Core\Contracts\BaseAdapterInterface' )
+            ->give( 'LibreEHR\FHIR\Adapters\FHIRAppointmentAdapter' );
+
+        // When Adapter needs Repository Logic point IoC to give the AppointmentRepository
+        $this->app->when( 'LibreEHR\FHIR\Adapters\FHIRAppointmentAdapter' )
+            ->needs( 'LibreEHR\Core\Contracts\RepositoryInterface' )
+            ->give( 'LibreEHR\Core\Emr\Repositories\AppointmentRepository' );
+
+
         // When PatientController needs Adapter Logic point IoC to give the FHIRPatientAdapter
         $this->app->when( 'LibreEHR\FHIR\Http\Controllers\PatientController' )
             ->needs( 'LibreEHR\Core\Contracts\BaseAdapterInterface' )

--- a/src/Utilities/Providers/FHIRServiceProvider.php
+++ b/src/Utilities/Providers/FHIRServiceProvider.php
@@ -24,6 +24,10 @@ class FHIRServiceProvider extends ServiceProvider
             return new \LibreEHR\Core\Emr\Eloquent\PatientData();
         });
 
+        // Set up Appointment binding
+        $this->app->bind('LibreEHR\Core\Contracts\AppointmentInterface', 'LibreEHR\Core\Emr\Eloquent\AppointmentData', function( $app ) {
+            return new \LibreEHR\Core\Emr\Eloquent\AppointmentData();
+        });
 
         // When AppointmentController needs Adapter Logic point IoC to give the FHIRAppointmentAdapter
         $this->app->when( 'LibreEHR\FHIR\Http\Controllers\AppointmentController' )


### PR DESCRIPTION
Implemented method interfaceToModel in FHIRAppointmentAdapter . For the test used only 3 fields. 
Table openemr_postcalendar_events contains 37 fields. Do I need to use all fields for implement API?
I can't understand how to use resources a schedule, and a slot as a separate entities. Do I need to create tables in the database for each resource?
